### PR TITLE
genericized api request functionality

### DIFF
--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -73,15 +73,12 @@ class GenericRequester(object):
         return GenericRequester(self.client, prefix=prefix)
 
     def __getattr__(self, name):
-        tokens = name.split('_')
-
-        method_name = tokens[0]
-        route = tokens[1:]
+        method_name = name
 
         if method_name in HTTP_VERBS_LOWER:
             method_call_name = '_{}'.format(method_name)
             method = getattr(self.client, method_call_name)
-            url = os.path.join(self.prefix, *route)
+            url = self.prefix
             return partial(method, url)
         else:
             return partial(self._requester, name)

--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -11,10 +11,28 @@ from flask import has_request_context, request, current_app
 import backoff
 from monotonic import monotonic
 
+import os
+from functools import partial
+
 from . import __version__
 from .errors import APIError, HTTPError, HTTPTemporaryError, InvalidResponse
 
 logger = logging.getLogger(__name__)
+
+
+HTTP_VERBS = [
+    'GET',
+    'HEAD',
+    'POST',
+    'PUT',
+    'DELETE',
+    'CONNECT',
+    'OPTIONS',
+    'TRACE',
+    'PATH'
+]
+
+HTTP_VERBS_LOWER = [_.lower() for _ in HTTP_VERBS]
 
 
 def make_iter_method(method_name, model_name, url_path):
@@ -42,11 +60,39 @@ def make_iter_method(method_name, model_name, url_path):
     return iter_method
 
 
+class GenericRequester(object):
+    def __init__(self, client, prefix='/'):
+        self.client = client
+        self.prefix = prefix
+
+    def _requester(self, *args):
+        tokens = ['/'] + list(str(_) for _ in args)
+        path = os.path.join(*tokens)
+        path = path.lstrip(os.sep)
+        prefix = os.path.join(self.prefix, path)
+        return GenericRequester(self.client, prefix=prefix)
+
+    def __getattr__(self, name):
+        tokens = name.split('_')
+
+        method_name = tokens[0]
+        route = tokens[1:]
+
+        if method_name in HTTP_VERBS_LOWER:
+            method_call_name = '_{}'.format(method_name)
+            method = getattr(self.client, method_call_name)
+            url = os.path.join(self.prefix, *route)
+            return partial(method, url)
+        else:
+            return partial(self._requester, name)
+
+
 class BaseAPIClient(object):
     def __init__(self, base_url=None, auth_token=None, enabled=True):
         self.base_url = base_url
         self.auth_token = auth_token
         self.enabled = enabled
+        self.req = GenericRequester(self)
 
     def _put(self, url, data):
         return self._request("PUT", url, data=data)

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -8,7 +8,6 @@ class DataAPIClient(BaseAPIClient):
     def init_app(self, app):
         self.base_url = app.config['DM_DATA_API_URL']
         self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
-
     # Audit Events
 
     def find_audit_events(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -387,7 +387,7 @@ class TestDataApiClient(object):
             json={"status": "ok"},
             status_code=200)
 
-        result = data_client.req.get_domains()
+        result = data_client.req.domains().get()
 
         assert result['status'] == "ok"
         assert rmock.called
@@ -399,19 +399,6 @@ class TestDataApiClient(object):
             status_code=200)
 
         result = data_client.req.suppliers(99).domains(5).approve().post(
-            data={}
-        )
-
-        assert result['status'] == "ok"
-        assert rmock.called
-
-    def test_post_supplier_domain_approval_generic_alternate_style(self, data_client, rmock):
-        rmock.post(
-            "http://baseurl/suppliers/99/domains/5/approve",
-            json={"status": "ok"},
-            status_code=200)
-
-        result = data_client.req.suppliers(99).domains(5).post_approve(
             data={}
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -381,6 +381,43 @@ class TestDataApiClient(object):
         assert result['status'] == "ok"
         assert rmock.called
 
+    def test_get_domains_generic(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/domains",
+            json={"status": "ok"},
+            status_code=200)
+
+        result = data_client.req.get_domains()
+
+        assert result['status'] == "ok"
+        assert rmock.called
+
+    def test_post_supplier_domain_approval_generic(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/99/domains/5/approve",
+            json={"status": "ok"},
+            status_code=200)
+
+        result = data_client.req.suppliers(99).domains(5).approve().post(
+            data={}
+        )
+
+        assert result['status'] == "ok"
+        assert rmock.called
+
+    def test_post_supplier_domain_approval_generic_alternate_style(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/99/domains/5/approve",
+            json={"status": "ok"},
+            status_code=200)
+
+        result = data_client.req.suppliers(99).domains(5).post_approve(
+            data={}
+        )
+
+        assert result['status'] == "ok"
+        assert rmock.called
+
     def test_get_archived_service(self, data_client, rmock):
         rmock.get(
             "http://baseurl/archived-services/123",


### PR DESCRIPTION
Context for this is dynamically generated api calls so I don't need to add specific calls for domain approvals.

For instance, assuming we have the route:

/suppliers/99/domains/5/assessed

Instead of creating a specific route, you just use method calls from the .req property like so:

data_client.req.suppliers(99).domains(5).assessed().post(data={})

Which generates a POST to the above URL, using some magic.