### PR TITLE
strip unnecssary / from path

### DIFF
--- a/dmapiclient/base.py
+++ b/dmapiclient/base.py
@@ -122,6 +122,7 @@ class BaseAPIClient(object):
         if not self.enabled:
             return None
 
+        url = url.lstrip('/')
         url = urlparse.urljoin(self.base_url, url)
 
         logger.debug("API request {method} {url}",


### PR DESCRIPTION
`urljoin('http://baseurl/api/', '/path')` returns `http://baseurl/path`
but
`urljoin('http://baseurl/api/', 'path')` returns `http://baseurl/api/path` 
 